### PR TITLE
Add HITL nodes for Unstract workflow processing

### DIFF
--- a/credentials/UnstractHITL.credentials.js
+++ b/credentials/UnstractHITL.credentials.js
@@ -1,0 +1,32 @@
+
+class UnstractHITL {
+    constructor() {
+        this.name = 'unstractHITL';
+        this.displayName = 'Unstract HITL';
+        this.documentationUrl = 'https://docs.unstract.com/unstract/index.html';
+        this.icon = 'file:llmWhisperer.svg';
+        this.properties = [
+            {
+                displayName: 'HITL Key',
+                name: 'HITLKey',
+                type: 'string',
+                typeOptions: {
+                    password: true,
+                },
+                default: '',
+                required: true,
+                description: 'The Bearer token for Unstract HITL API',
+            },
+            {
+                displayName: 'Organization ID',
+                name: 'orgId',
+                type: 'string',
+                default: '',
+                required: true,
+                description: 'Your Unstract Organization ID',
+            },
+        ];
+    }
+}
+
+module.exports = { UnstractHITL };

--- a/nodes/UnstractHITLFetch.node.js
+++ b/nodes/UnstractHITLFetch.node.js
@@ -1,0 +1,105 @@
+const { NodeOperationError } = require('n8n-workflow');
+
+class UnstractHITLFetch {
+    constructor() {
+        this.description = {
+            displayName: 'Unstract HITL Fetch',
+            name: 'unstractHitlFetch',
+            icon: 'file:llmWhisperer.svg',
+            group: ['transform'],
+            version: 1,
+            description: 'Fetch final result from HITL queue using Unstract API',
+            defaults: {
+                name: 'Unstract HITL Fetch',
+            },
+            inputs: ['main'],
+            outputs: ['main'],
+            credentials: [
+                {
+                    name: 'unstractHITL',
+                    required: true,
+                },
+            ],
+            properties: [
+                {
+                    displayName: 'Unstract Host',
+                    name: 'host',
+                    type: 'string',
+                    default: 'http://localhost:8000',
+                    required: true,
+                },
+                {
+                    displayName: 'Workflow ID',
+                    name: 'workflow_id',
+                    type: 'string',
+                    default: '',
+                    required: true,
+                },
+                {
+                    displayName: 'HITL Queue Name',
+                    name: 'hitl_queue_name',
+                    type: 'string',
+                    default: '',
+                    required: true,
+                },
+            ],
+        };
+    }
+
+    async execute() {
+        const items = this.getInputData();
+        const returnData = [];
+
+        const credentials = await this.getCredentials('unstractHITL');
+        const hitlKey = credentials.HITLKey;
+        const orgId = credentials.orgId;
+
+        const helpers = this.helpers;
+
+        for (let i = 0; i < items.length; i++) {
+            const host = this.getNodeParameter('host', i);
+            const workflowId = this.getNodeParameter('workflow_id', i);
+            const hitlQueueName = this.getNodeParameter('hitl_queue_name', i);
+
+            const url = `${host}/mr/api/${orgId}/approved/result/${workflowId}/?hitl_queue_name=${encodeURIComponent(hitlQueueName)}`;
+
+            const options = {
+                method: 'GET',
+                url,
+                headers: {
+                    Authorization: `Bearer ${hitlKey}`,
+                },
+            };
+
+            try {
+                const response = await helpers.request(options);
+                const parsed = typeof response === 'string' ? JSON.parse(response) : response;
+
+                if (parsed.error) {
+                    if (parsed.error === 'No approved items available.') {
+                        returnData.push({ json: { message: 'No approved items available', hasData: false } });
+                    } else {
+                        throw new NodeOperationError(this.getNode(), `API Error: ${parsed.error}`);
+                    }
+                } else if (parsed.data) {
+                    returnData.push({ json: { ...parsed.data, hasData: true } });
+                } else {
+                    throw new NodeOperationError(this.getNode(), 'Unexpected response format.');
+                }
+
+            } catch (error) {
+                if (error.response && error.response.statusCode === 404) {
+                    throw new NodeOperationError(this.getNode(), 'Result not yet available (404)');
+                }
+                if (error.response && error.response.statusCode === 500) {
+                    throw new NodeOperationError(this.getNode(), 'Server error (500)');
+                }
+                throw new NodeOperationError(this.getNode(), `Failed to fetch HITL result: ${error.message}`);
+            }
+        }
+
+        return [returnData];
+    }
+}
+
+module.exports = { UnstractHITLFetch };

--- a/nodes/UnstractHITLPush.node.js
+++ b/nodes/UnstractHITLPush.node.js
@@ -1,0 +1,211 @@
+const { NodeOperationError } = require('n8n-workflow');
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+class UnstractHITLPush {
+    constructor() {
+        this.description = {
+            displayName: 'Unstract HITL Push',
+            name: 'unstractHitlPush',
+            icon: 'file:llmWhisperer.svg',
+            group: ['transform'],
+            version: 1,
+            description: 'Push document for HITL processing using Unstract API',
+            defaults: {
+                name: 'Unstract HITL Push',
+            },
+            inputs: ['main'],
+            outputs: ['main'],
+            credentials: [
+                {
+                    name: 'unstractApi',
+                    required: true,
+                },
+            ],
+            inputDataType: ['binary'],
+            properties: [
+                {
+                    displayName: 'File Contents',
+                    name: 'file_contents',
+                    type: 'string',
+                    default: 'data',
+                    description: 'Name of the binary property containing file data',
+                    required: true,
+                },
+                {
+                    displayName: 'Unstract Host',
+                    name: 'host',
+                    type: 'string',
+                    default: 'https://us-central.unstract.com',
+                    required: true,
+                },
+                {
+                    displayName: 'API Deployment Name',
+                    name: 'deployment_name',
+                    type: 'string',
+                    default: '',
+                    required: true,
+                },
+                {
+                    displayName: 'HITL Queue Name',
+                    name: 'hitl_queue_name',
+                    type: 'string',
+                    default: '',
+                    required: true,
+                },
+                {
+                    displayName: 'Timeout',
+                    name: 'timeout',
+                    type: 'number',
+                    default: 600,
+                    description: 'Max seconds to wait for processing',
+                    required: true,
+                },
+                {
+                    displayName: 'Include Metrics',
+                    name: 'include_metrics',
+                    type: 'boolean',
+                    default: true,
+                },
+                {
+                    displayName: 'Include Metadata',
+                    name: 'include_metadata',
+                    type: 'boolean',
+                    default: true,
+                },
+                {
+                    displayName: 'Tags',
+                    name: 'tags',
+                    type: 'string',
+                    default: '',
+                    description: 'Comma-separated tags for the document',
+                },
+                {
+                    displayName: 'Use cached results',
+                    name: 'use_file_history',
+                    type: 'boolean',
+                    default: false,
+                },
+            ],
+        };
+    }
+
+    async execute() {
+        const items = this.getInputData();
+        const returnData = [];
+
+        try {
+            const credentials = await this.getCredentials('unstractApi');
+            const apiKey = credentials.apiKey;
+            const orgId = credentials.orgId;
+            const { helpers, logger } = this;
+
+            for (let i = 0; i < items.length; i++) {
+                const binaryPropertyName = this.getNodeParameter('file_contents', i);
+                if (!items[i].binary?.[binaryPropertyName]) {
+                    throw new NodeOperationError(this.getNode(), `No binary data property "${binaryPropertyName}" exists on input`);
+                }
+
+                const binaryData = items[i].binary[binaryPropertyName];
+                const fileBuffer = Buffer.from(binaryData.data, 'base64');
+
+                const timeout = this.getNodeParameter('timeout', i);
+                const deploymentName = this.getNodeParameter('deployment_name', i);
+                const host = this.getNodeParameter('host', i);
+                const includeMetrics = this.getNodeParameter('include_metrics', i);
+                const includeMetadata = this.getNodeParameter('include_metadata', i);
+                const tags = this.getNodeParameter('tags', i);
+                const useFileHistory = this.getNodeParameter('use_file_history', i);
+                const hitlQueueName = this.getNodeParameter('hitl_queue_name', i);
+
+                const formData = {
+                    files: {
+                        value: fileBuffer,
+                        options: {
+                            filename: binaryData.fileName,
+                            contentType: binaryData.mimeType,
+                        },
+                    },
+                    timeout: 1,
+                    include_metrics: includeMetrics.toString(),
+                    include_metadata: includeMetadata.toString(),
+                    use_file_history: useFileHistory.toString(),
+                    hitl_queue_name: hitlQueueName,
+                };
+
+                if (tags) {
+                    formData.tags = tags;
+                }
+
+                const requestOptions = {
+                    method: 'POST',
+                    url: `${host}/deployment/api/${orgId}/${deploymentName}/`,
+                    headers: {
+                        Authorization: `Bearer ${apiKey}`,
+                    },
+                    formData,
+                    timeout: 5 * 60 * 1000,
+                };
+
+                logger.info('[HITL] Sending file to Unstract HITL API...');
+                let result = await helpers.request(requestOptions);
+                let resultContent = JSON.parse(result).message;
+                let execution_status = resultContent.execution_status;
+
+                if (execution_status === 'PENDING' || execution_status === 'EXECUTING') {
+                    const status_api = resultContent.status_api;
+                    const t1 = new Date();
+
+                    while (execution_status !== 'COMPLETED') {
+                        await sleep(2000);
+
+                        const pollRequest = {
+                            method: 'GET',
+                            url: `${host}${status_api}`,
+                            headers: {
+                                Authorization: `Bearer ${apiKey}`,
+                            },
+                            timeout: 5 * 60 * 1000,
+                        };
+
+                        try {
+                            const pollResult = await helpers.request(pollRequest);
+                            resultContent = JSON.parse(pollResult);
+                            execution_status = resultContent.status;
+                        } catch (error) {
+                            if (error.response && error.response.statusCode === 400) {
+                                throw new NodeOperationError(this.getNode(), `Polling error: ${error}`);
+                            }
+                            let json = error.message.split(' - ')[1];
+                            json = json.replace(/\\"/g, '"').slice(1, -1);
+                            resultContent = JSON.parse(json);
+                            execution_status = resultContent.status;
+                        }
+
+                        const t2 = new Date();
+                        if ((t2 - t1) / 1000 > timeout) {
+                            throw new NodeOperationError(this.getNode(), `Timeout reached: ${timeout} seconds`);
+                        }
+                        if (execution_status === 'ERROR') {
+                            throw new NodeOperationError(this.getNode(), `Error: ${resultContent.message[0]?.error}`);
+                        }
+                        if (execution_status === 'COMPLETED') {
+                            resultContent = resultContent.message;
+                        }
+                    }
+                }
+
+                returnData.push({ json: resultContent });
+            }
+
+            return [returnData];
+        } catch (error) {
+            if (error.message) {
+                throw new NodeOperationError(this.getNode(), error.message);
+            }
+            throw error;
+        }
+    }
+}
+
+module.exports = { UnstractHITLPush };


### PR DESCRIPTION
## Summary
- Added UnstractHITLPush node for pushing documents to HITL queues
- Added UnstractHITLFetch node for retrieving approved results from HITL queues  
- Added UnstractHITL credentials for HITL-specific authentication
- Updated package version to 0.2.1

## Changes Made
### New Files
- `credentials/UnstractHITL.credentials.js` - HITL-specific credentials with HITLKey authentication
- `nodes/UnstractHITLPush.node.js` - Node for pushing documents to HITL processing queues
- `nodes/UnstractHITLFetch.node.js` - Node for fetching approved results from HITL queues

### Key Features
- **HITL Push Node**: Supports document upload with configurable timeout, metrics, metadata, and queue targeting
- **HITL Fetch Node**: Polls for approved results with proper error handling for "No approved items available" responses
- **Dedicated Credentials**: Separate HITL credentials using HITLKey instead of standard API key
- **Streamlined API**: Removed unnecessary `push_to_hitl` parameter and simplified queue name handling

## Test plan
- [ ] Test HITL Push node with various document types and queue configurations
- [ ] Test HITL Fetch node polling for both available and unavailable results
- [ ] Verify credential authentication works with HITL endpoints
- [ ] Test error handling for network issues and API errors

🤖 Generated with [Claude Code](https://claude.ai/code)