### PR TITLE
fix: prevent npm version error when package.json already has target version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,8 +115,16 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version from release: $VERSION"
 
-          # Update package.json to match release version
-          npm version $VERSION --no-git-tag-version
+          # Check if version needs to be updated
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "Current package.json version: $CURRENT_VERSION"
+
+          if [ "$CURRENT_VERSION" != "$VERSION" ]; then
+            echo "Updating package.json version from $CURRENT_VERSION to $VERSION"
+            npm version $VERSION --no-git-tag-version
+          else
+            echo "Package.json version is already $VERSION, skipping update"
+          fi
 
           # Commit version changes if needed
           if ! git diff --quiet package.json; then


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the GitHub Actions workflow that was causing the release process to fail with "npm ERR! Version not changed" error when trying to sync package.json version with GitHub releases.

## Problem

The workflow was failing during the release event handling with the following error:

```
Run VERSION="v0.3.0"
Extracted version from release: 0.3.0
npm ERR! Version not changed

npm ERR! A complete log of this run can be found in: /home/runner/.npm/_logs/2025-07-17T09_49_55_587Z-debug-0.log
Error: Process completed with exit code 1.
```

## Root Cause

The issue occurred when the package.json already contained the target version (e.g., `0.3.0`) but the workflow still attempted to run `npm version 0.3.0 --no-git-tag-version`, causing npm to throw an error because the version wasn't actually changing.

This commonly happens when:
- Re-running a failed release workflow
- Package.json was already updated in a previous run
- Manual version updates were made before the release

## Solution

Added a version comparison check before attempting to update package.json:

### Before (Problematic)
```yaml
# Update package.json to match release version
npm version $VERSION --no-git-tag-version
```

### After (Fixed)
```yaml
# Check if version needs to be updated
CURRENT_VERSION=$(node -p "require('./package.json').version")
echo "Current package.json version: $CURRENT_VERSION"

if [ "$CURRENT_VERSION" != "$VERSION" ]; then
  echo "Updating package.json version from $CURRENT_VERSION to $VERSION"
  npm version $VERSION --no-git-tag-version
else
  echo "Package.json version is already $VERSION, skipping update"
fi
```

## Changes

### 🔧 Bug Fixes
- **Version Check**: Added comparison between current and target versions
- **Skip Logic**: Skip npm version command when versions match
- **Enhanced Logging**: Added debug output to show version comparison results
- **Error Prevention**: Prevents npm version command from failing on unchanged versions

### 🚀 Improvements
- **Idempotent Workflow**: Workflow can now be safely re-run without errors
- **Better Error Handling**: More descriptive output when version updates are skipped
- **Robust Release Process**: Handles edge cases gracefully

## Testing Scenarios

- [x] **New Release**: When package.json version differs from release tag → Updates version ✅
- [x] **Re-run Release**: When package.json version matches release tag → Skips update ✅
- [x] **Version Sync**: Only commits changes if actual differences exist ✅
- [x] **Manual Triggers**: Existing manual version bump functionality unaffected ✅

## Impact

### ✅ **Fixes**
- Resolves "Version not changed" npm errors
- Enables successful re-runs of failed release workflows
- Prevents workflow failures due to version synchronization issues

### ✅ **Benefits**
- More reliable release process
- Better debugging information
- Reduced manual intervention required
- Maintains backward compatibility

## Breaking Changes

None. This is a pure bug fix that maintains all existing functionality while preventing errors.

## Related Issues

- Fixes release workflow failures due to npm version errors
- Addresses workflow reliability issues during re-runs
- Improves error handling in automated release process

## Checklist

- [x] Added version comparison logic before npm version command
- [x] Enhanced logging for better debugging
- [x] Maintained existing workflow functionality
- [x] Tested with both new and existing version scenarios
- [x] Verified workflow can be safely re-run
- [x] Confirmed no breaking changes to existing behavior