### PR TITLE
feat: Add HITL (Human-in-the-Loop) nodes to n8n package

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,14 @@
     "n8nNodesApiVersion": 1,
     "credentials": [
       "dist/credentials/LLMWhispererApi.credentials.js",
-      "dist/credentials/UnstractApi.credentials.js"
+      "dist/credentials/UnstractApi.credentials.js",
+      "dist/credentials/UnstractHITL.credentials.js"
     ],
     "nodes": [
       "dist/nodes/LLMWhisperer.node.js",
-      "dist/nodes/Unstract.node.js"
+      "dist/nodes/Unstract.node.js",
+      "dist/nodes/UnstractHITLFetch.node.js",
+      "dist/nodes/UnstractHITLPush.node.js"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

This PR adds the new UnstractHITLFetch and UnstractHITLPush nodes to the package.json configuration, enabling n8n to properly load and register these nodes for Human-in-the-Loop (HITL) document processing workflows.

## Changes

- Added UnstractHITLFetch.node.js to the nodes array in package.json
- Added UnstractHITLPush.node.js to the nodes array in package.json  
- Added UnstractHITL.credentials.js to the credentials array in package.json

## Motivation

The HITL nodes were implemented but not registered in the package.json configuration, preventing n8n from loading them. This fix ensures:

1. **UnstractHITLPush** - Pushes documents for HITL processing using Unstract API
2. **UnstractHITLFetch** - Fetches final results from HITL queue using Unstract API
3. **UnstractHITL credentials** - Provides authentication for HITL fetch operations

## Related Issues

N/A - This is a configuration fix for existing node implementations.

## Testing

- [x] Verified that all referenced node files exist in the nodes/ directory
- [x] Verified that all referenced credential files exist in the credentials/ directory
- [x] Confirmed UnstractHITLPush uses unstractApi credentials (already configured)
- [x] Confirmed UnstractHITLFetch uses unstractHITL credentials (now properly configured)

## Checklist

- [x] Code follows the project's coding standards
- [x] No breaking changes introduced
- [x] All required files are properly referenced in package.json
- [x] Commit message follows conventional commit format
- [x] Changes are focused and atomic