### PR TITLE
feat: enhance prepublish checks and fix TypeScript compliance

### DIFF
--- a/credentials/UnstractHITLApi.credentials.ts
+++ b/credentials/UnstractHITLApi.credentials.ts
@@ -3,9 +3,9 @@ import {
 	INodeProperties,
 } from 'n8n-workflow';
 
-export class UnstractHITL implements ICredentialType {
-	name = 'unstractHITL';
-	displayName = 'Unstract HITL';
+export class UnstractHITLApi implements ICredentialType {
+	name = 'unstractHITLApi';
+	displayName = 'Unstract HITL API';
 	documentationUrl = 'https://docs.unstract.com/unstract/index.html';
 	icon = 'file:llmWhisperer.svg' as const;
 	

--- a/nodes/LlmWhisperer/LlmWhisperer.node.ts
+++ b/nodes/LlmWhisperer/LlmWhisperer.node.ts
@@ -23,7 +23,7 @@ const sleep = (ms: number): Promise<void> =>
 		check();
 	});
 
-export class LLMWhisperer implements INodeType {
+export class LlmWhisperer implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'LLMWhisperer',
 		name: 'llmWhisperer',

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "build": "npx rimraf dist && tsc && gulp build:icons",
     "dev": "tsc --watch",
     "format": "prettier nodes credentials --write",
-    "lint": "eslint nodes/**/*.ts package.json",
-    "lintfix": "eslint nodes/**/*.ts package.json --fix",
-    "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes credentials package.json"
+    "lint": "eslint nodes/**/*.ts credentials/**/*.ts package.json",
+    "lintfix": "eslint nodes/**/*.ts credentials/**/*.ts package.json --fix",
+    "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes credentials package.json && npm audit --audit-level=high"
   },
   "files": [
     "dist",


### PR DESCRIPTION
- Add security audit to prepublish script for n8n compatibility
- Fix LLMWhisperer class name casing (LLMWhisperer -> LlmWhisperer)
- Rename UnstractHITL credentials to UnstractHITLApi for consistency
- Include credentials in lint scripts for comprehensive checking